### PR TITLE
frostyrc_fixes

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/frosty/frostyrc/RcScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/frosty/frostyrc/RcScript.java
@@ -710,6 +710,9 @@ public class RcScript extends Script {
             Microbot.log("Crafting runes");
             handleEmptyPouch();
         }
+
+		handleFeroxRunEnergy();
+
         state = State.BANKING;
     }
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/frosty/frostyrc/RcScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/frosty/frostyrc/RcScript.java
@@ -713,6 +713,10 @@ public class RcScript extends Script {
 
 		handleFeroxRunEnergy();
 
+		if (plugin.isBreakHandlerEnabled()) {
+			BreakHandlerScript.setLockState(false);
+		}
+
         state = State.BANKING;
     }
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/frosty/frostyrc/RcScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/frosty/frostyrc/RcScript.java
@@ -459,7 +459,12 @@ public class RcScript extends Script {
             Microbot.log("Interacting with myth cape");
             Rs2Inventory.interact(mythCape, "Teleport");
             sleepUntil(() -> plugin.getMyWorldPoint().getRegionID() == mythicStatueRegion);
-            sleepGaussian(1100, 200);
+            sleepGaussian(600, 200);
+
+			GameObject statue = Rs2GameObject.get("Mythic Statue");
+			if (statue != null && !Rs2Player.isAnimating()) {
+				Rs2GameObject.interact(statue, "Teleport");
+			}
 
             if (plugin.getMyWorldPoint().getRegionID() == mythicStatueRegion) {
                 Microbot.log("Walking to Wrath ruins");

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/frosty/frostyrc/RcScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/frosty/frostyrc/RcScript.java
@@ -334,6 +334,7 @@ public class RcScript extends Script {
     private void handleFeroxRunEnergy() {
 		if (forceDrinkAtFerox || Rs2Player.getRunEnergy() <= 15 || Rs2Player.getHealthPercentage() <= 20) {
 			Microbot.log("We are thirsty...let us Drink");
+            forceDrinkAtFerox = true;
             if (plugin.getMyWorldPoint().distanceTo(feroxPoolWp) > 5) {
                 Microbot.log("Walking to Ferox pool");
                 Rs2Walker.walkTo(feroxPoolWp);
@@ -746,7 +747,13 @@ public class RcScript extends Script {
         Rs2Tab.switchToEquipmentTab();
         sleepGaussian(1300, 200);
 
-        List<Teleports> bankTeleport = Arrays.asList(
+        boolean needRefill = (forceDrinkAtFerox || Rs2Player.getRunEnergy() <= 15 || Rs2Player.getHealthPercentage() <= 20);
+        List<Teleports> bankTeleport = needRefill
+                ? Arrays.asList(
+                Teleports.FEROX_ENCLAVE,
+                Teleports.CRAFTING_CAPE,
+                Teleports.FARMING_CAPE)
+                : Arrays.asList(
                 Teleports.CRAFTING_CAPE,
                 Teleports.FARMING_CAPE,
                 Teleports.FEROX_ENCLAVE

--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/frosty/frostyrc/RcScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/frosty/frostyrc/RcScript.java
@@ -48,6 +48,8 @@ public class RcScript extends Script {
     private final WorldPoint outsideWrathRuins = new WorldPoint(2445, 2818, 0);
     private final WorldPoint wrathRuinsLoc = new WorldPoint(2445, 2824, 0);
 
+	private volatile boolean forceDrinkAtFerox = false;
+
     public static final int pureEss = 7936;
     public static final int feroxPool = 39651;
     public static final int monasteryRegion = 10290;
@@ -330,8 +332,8 @@ public class RcScript extends Script {
     }
 
     private void handleFeroxRunEnergy() {
-        if (Rs2Player.getRunEnergy() < 45) {
-            Microbot.log("We are thirsty...let us Drink");
+		if (forceDrinkAtFerox || Rs2Player.getRunEnergy() <= 15 || Rs2Player.getHealthPercentage() <= 20) {
+			Microbot.log("We are thirsty...let us Drink");
             if (plugin.getMyWorldPoint().distanceTo(feroxPoolWp) > 5) {
                 Microbot.log("Walking to Ferox pool");
                 Rs2Walker.walkTo(feroxPoolWp);
@@ -344,6 +346,7 @@ public class RcScript extends Script {
             }
             sleepUntil(() -> (!Rs2Player.isInteracting()) && !Rs2Player.isAnimating() && Rs2Player.getRunEnergy() > 90);
             sleepGaussian(1100, 200);
+			forceDrinkAtFerox = false;
         }
     }
 
@@ -745,6 +748,10 @@ public class RcScript extends Script {
                     Rs2Equipment.interact(bankTeleportsId, teleport.getInteraction());
                     sleepUntil(() -> teleport.matchesRegion(plugin.getMyWorldPoint().getRegionID()));
                     sleepGaussian(1100, 200);
+					if (teleport == Teleports.FEROX_ENCLAVE) {
+						forceDrinkAtFerox = true;
+						handleFeroxRunEnergy();
+					}
                     teleportUsed = true;
                     break;
                 }


### PR DESCRIPTION
Fixed logic that bounced back to bank after already teleporting to Ferox.
Faster walking to wrath ruins.
Fixed getting stuck after break by allowing breaks after runecrafting finishes.
Fixed getting stuck after bank teleport by checking energy/health first.
Fixed not drinking at ferox if energy/health recovered before drinking.