### PR TITLE
Respect logout setting in Break Handler

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/microbot/breakhandler/BreakHandlerScript.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/microbot/breakhandler/BreakHandlerScript.java
@@ -324,7 +324,9 @@ public class BreakHandlerScript extends Script {
         PluginPauseEvent.setPaused(true);
         Rs2Walker.setTarget(null);
         // Determine next state based on break type
-        if (Rs2AntibanSettings.microBreakActive && (config.onlyMicroBreaks() || !shouldLogout())) {
+        boolean logout = shouldLogout();
+
+        if (!logout || (Rs2AntibanSettings.microBreakActive && config.onlyMicroBreaks())) {
             setBreakDuration();
             transitionToState(BreakHandlerState.MICRO_BREAK_ACTIVE);
         } else {


### PR DESCRIPTION
## Summary
- fix BreakHandlerScript to consult config before logging out

## Testing
- `mvn -q -e -pl runelite-client -am test` *(fails: Non-resolvable import POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68b3586f6d3c832684e0464afefa62c6